### PR TITLE
Fix intermittent cursor size issue in editor

### DIFF
--- a/src/components/PageEditor.css
+++ b/src/components/PageEditor.css
@@ -107,9 +107,11 @@
   color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: 0.9rem;
-  line-height: 1.7;
+  line-height: 1.7em;
   resize: vertical;
   tab-size: 2;
+  caret-color: var(--text-primary);
+  font-variant-ligatures: none;
 }
 
 .editor-textarea:focus {

--- a/src/lib/slash-commands/useSlashCommands.ts
+++ b/src/lib/slash-commands/useSlashCommands.ts
@@ -62,7 +62,11 @@ function getCaretCoordinates(
     lineHeight,
   };
 
-  document.body.removeChild(div);
+  try {
+    document.body.removeChild(div);
+  } catch {
+    div.remove();
+  }
 
   return result;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -162,6 +162,7 @@ input, textarea {
   border-radius: 6px;
   background-color: var(--bg-primary);
   color: var(--text-primary);
+  font-synthesis: none;
 }
 
 input:focus, textarea:focus {


### PR DESCRIPTION
## Summary
- Change textarea `line-height` from unitless `1.7` to `1.7em` for font-relative caret sizing
- Add `font-variant-ligatures: none` to prevent Fira Code ligature metric shifts
- Add `font-synthesis: none` to all input/textarea elements globally
- Add try-catch safeguard for mirror div cleanup in slash command caret detection

## Issue
Addresses Issue #1 item: "커서 사이즈가 이상하게 커지는 현상 간헐적으로 관찰됨"

## Files Changed
- `src/components/PageEditor.css` — caret-color, em line-height, no ligatures
- `src/styles/global.css` — font-synthesis: none on inputs
- `src/lib/slash-commands/useSlashCommands.ts` — mirror div cleanup safety

## Test plan
- [ ] Open editor, type Korean text, verify caret stays consistent size
- [ ] Toggle between slash command palette and normal typing
- [ ] Verify caret behaves correctly with Fira Code loaded vs fallback font

🤖 Generated with [Claude Code](https://claude.com/claude-code)