### PR TITLE
Improve styling: Pretendard font, unified line-height, card excerpts

### DIFF
--- a/src/components/PageEditor.css
+++ b/src/components/PageEditor.css
@@ -139,7 +139,7 @@
   border-top: 1px solid var(--border-color);
   border-radius: 0;
   min-height: 400px;
-  line-height: 1.8;
+  line-height: var(--line-height-content);
 }
 
 /* Column/tag chip selector */
@@ -285,7 +285,7 @@
   border-radius: 12px !important;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15), 0 0 0 1px rgba(255, 255, 255, 0.1) !important;
   z-index: 999999 !important;
-  font-family: 'Asta Sans', sans-serif !important;
+  font-family: var(--font-sans) !important;
   font-size: 18px !important;
   font-weight: 600 !important;
   min-width: 280px !important;

--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -28,7 +28,8 @@
 }
 
 .sidebar-header h2 {
-  font-family: 'Lobster', cursive;
+  font-family: var(--font-sans);
+  font-weight: 700;
   font-size: 1.25rem;
   margin: 0;
 }

--- a/src/pages/Home.css
+++ b/src/pages/Home.css
@@ -12,7 +12,8 @@
 }
 
 .welcome-card h1 {
-  font-family: 'Lobster', cursive;
+  font-family: var(--font-sans);
+  font-weight: 700;
   font-size: 3rem;
   margin-bottom: 1rem;
 }
@@ -318,7 +319,7 @@
   line-height: 1.4;
   margin: 0;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }

--- a/src/pages/PageView.css
+++ b/src/pages/PageView.css
@@ -103,7 +103,7 @@
 
 /* Document view */
 .document-view {
-  line-height: 1.3;
+  line-height: var(--line-height-content);
   padding: 0rem 2rem 2rem 2rem;
 }
 

--- a/src/services/markdown.ts
+++ b/src/services/markdown.ts
@@ -84,9 +84,11 @@ export class MarkdownService {
    * @param markdown - Markdown content
    * @param maxLength - Maximum length of excerpt
    */
-  getExcerpt(markdown: string, maxLength: number = 150): string {
+  getExcerpt(markdown: string, maxLength: number = 80): string {
     // Remove markdown syntax for plain text
     let text = markdown
+      .replace(/- \[[ x]\]\s*/g, '') // Checkboxes
+      .replace(/!\[.*?\]\(.*?\)/g, '') // Images
       .replace(/#{1,6}\s+/g, '') // Headers
       .replace(/\*\*(.+?)\*\*/g, '$1') // Bold
       .replace(/\*(.+?)\*/g, '$1') // Italic

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,5 @@
+@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.min.css');
+
 * {
   box-sizing: border-box;
   margin: 0;
@@ -17,8 +19,9 @@
   --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.1);
   --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.1);
 
-  --font-sans: 'Asta Sans', sans-serif;
+  --font-sans: 'Pretendard', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
   --font-mono: 'Fira Code', 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace;
+  --line-height-content: 1.6;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -50,6 +53,7 @@ body {
   background-color: var(--bg-primary);
   color: var(--text-primary);
   line-height: 1.6;
+  letter-spacing: -0.01em;
 }
 
 #root {
@@ -130,7 +134,7 @@ button {
 .btn {
   padding: 0.5rem 1rem;
   border-radius: 6px;
-  font-family: 'Asta Sans', sans-serif;
+  font-family: var(--font-sans);
   font-weight: 600;
   transition: all 0.2s;
 }


### PR DESCRIPTION
## Summary
- Replace Asta Sans/Lobster fonts with Pretendard (better Korean support)
- Add `--line-height-content` CSS variable, unify preview & detail view to `1.6`
- Add `letter-spacing: -0.01em` for tighter Korean character spacing
- Reduce card excerpt to 1 line, improve markdown syntax stripping

## Issue
Addresses Issue #1 items:
- "자간 수정 - 미적으로 별로임, 폰트 수정 - 못생겼다"
- "페이지 편집화면 내 preview 와 실제 상세화면간 line height 일치하도록 수정"
- "카드 미리보기로 2줄 나타나는 부분 지저분해서 제거하는게 나을지 판단 필요"

## Files Changed
- `src/styles/global.css` — Pretendard import, font-sans variable, letter-spacing, btn font
- `src/components/PageEditor.css` — preview line-height, toast font
- `src/components/Sidebar.css` — header font
- `src/pages/PageView.css` — document-view line-height
- `src/pages/Home.css` — welcome title font, card excerpt 1-line clamp
- `src/services/markdown.ts` — excerpt: strip checkboxes/images, reduce to 80 chars

## Test plan
- [ ] Verify Pretendard font loads correctly (Korean + English)
- [ ] Compare preview vs detail view line-height — should match
- [ ] Check card excerpts show 1 clean line without markdown artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)