### PR TITLE
Add editor keyboard shortcuts: tab, formatting, edit mode

### DIFF
--- a/src/hooks/useMarkdownShortcuts.ts
+++ b/src/hooks/useMarkdownShortcuts.ts
@@ -1,0 +1,77 @@
+import { RefObject, useCallback, KeyboardEvent } from 'react';
+
+function toggleWrap(
+  textarea: HTMLTextAreaElement,
+  content: string,
+  setContent: (s: string) => void,
+  marker: string
+) {
+  const start = textarea.selectionStart;
+  const end = textarea.selectionEnd;
+  const selected = content.slice(start, end);
+  const len = marker.length;
+
+  // Check if already wrapped
+  const before = content.slice(Math.max(0, start - len), start);
+  const after = content.slice(end, end + len);
+
+  if (before === marker && after === marker) {
+    // Remove wrapping
+    const newContent = content.slice(0, start - len) + selected + content.slice(end + len);
+    setContent(newContent);
+    requestAnimationFrame(() => {
+      textarea.setSelectionRange(start - len, end - len);
+      textarea.focus();
+    });
+  } else if (selected) {
+    // Wrap selection
+    const newContent = content.slice(0, start) + marker + selected + marker + content.slice(end);
+    setContent(newContent);
+    requestAnimationFrame(() => {
+      textarea.setSelectionRange(start + len, end + len);
+      textarea.focus();
+    });
+  } else {
+    // No selection: insert markers and place cursor between
+    const newContent = content.slice(0, start) + marker + marker + content.slice(end);
+    setContent(newContent);
+    requestAnimationFrame(() => {
+      textarea.setSelectionRange(start + len, start + len);
+      textarea.focus();
+    });
+  }
+}
+
+export function useMarkdownShortcuts(
+  textareaRef: RefObject<HTMLTextAreaElement | null>,
+  content: string,
+  setContent: (s: string) => void
+) {
+  const handleMarkdownShortcut = useCallback(
+    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (!(e.metaKey || e.ctrlKey)) return false;
+      const textarea = textareaRef.current;
+      if (!textarea) return false;
+
+      switch (e.key) {
+        case 'b':
+          e.preventDefault();
+          toggleWrap(textarea, content, setContent, '**');
+          return true;
+        case 'i':
+          e.preventDefault();
+          toggleWrap(textarea, content, setContent, '*');
+          return true;
+        case 'e':
+          e.preventDefault();
+          toggleWrap(textarea, content, setContent, '`');
+          return true;
+        default:
+          return false;
+      }
+    },
+    [textareaRef, content, setContent]
+  );
+
+  return { handleMarkdownShortcut };
+}

--- a/src/pages/PageView.tsx
+++ b/src/pages/PageView.tsx
@@ -114,6 +114,34 @@ export function PageView() {
     setEditing(false);
   };
 
+  // Keyboard shortcuts for edit mode
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Prevent Cmd+S when not editing
+      if ((e.metaKey || e.ctrlKey) && e.key === 's' && !editing) {
+        e.preventDefault();
+        return;
+      }
+
+      // Cmd+E or just E key to enter edit mode (when not in an input)
+      const target = e.target as HTMLElement;
+      const isInputField = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
+
+      if (!editing && !isInputField) {
+        if ((e.metaKey || e.ctrlKey) && e.key === 'e') {
+          e.preventDefault();
+          setEditing(true);
+        } else if (e.key === 'e' || e.key === 'E') {
+          e.preventDefault();
+          setEditing(true);
+        }
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [editing]);
+
   if (loading) {
     return (
       <div className="page-view">


### PR DESCRIPTION
## Summary
- Tab key inserts 2 spaces (Shift+Tab outdents), multi-line indent support
- `Cmd+B` (bold), `Cmd+I` (italic), `Cmd+E` (inline code) toggle shortcuts
- New `useMarkdownShortcuts` hook for reusable formatting logic
- `E` key enters edit mode from detail view, `Escape` exits editor
- `Cmd+S` suppressed in detail view to prevent browser save dialog

## Issue
Addresses Issue #1 items:
- "tab 클릭시 code editor 처럼 스페이싱 들어가도록 처리"
- "코드 블럭 및 코드 단어 단위 하이라이트 처리, 볼드 처리 손쉽게 할 수 있도록 기능 구현"
- "cmd + s 저장 동작, edit mode 진입 short cut key 지원"

## Files Changed
- `src/hooks/useMarkdownShortcuts.ts` — NEW: toggleWrap logic + Cmd+B/I/E handler
- `src/components/PageEditor.tsx` — handleEditorKeyDown with tab/escape/formatting
- `src/pages/PageView.tsx` — E key + Cmd+S keydown listener

## Test plan
- [ ] Press Tab in editor — should insert 2 spaces (not move focus)
- [ ] Select text, press Cmd+B — should wrap with `**`
- [ ] Press Cmd+B again on wrapped text — should unwrap
- [ ] Press E on detail view — should enter edit mode
- [ ] Press Escape in editor — should exit edit mode
- [ ] Press Cmd+S on detail view — should NOT open browser save dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)