### PR TITLE
Add image insertion: paste, drag-and-drop, file picker

### DIFF
--- a/src/components/PageEditor.css
+++ b/src/components/PageEditor.css
@@ -43,6 +43,17 @@
   color: var(--text-primary);
 }
 
+.toolbar-btn.image-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.375rem 0.5rem;
+}
+
+.toolbar-btn.image-btn .material-symbols-outlined {
+  font-size: 1.125rem;
+}
+
 .editor-meta {
   margin-bottom: 0.5rem;
   padding: 0 2rem;

--- a/src/components/PageEditor.tsx
+++ b/src/components/PageEditor.tsx
@@ -5,6 +5,33 @@ import { useStore } from '@/store/useStore';
 import { useSlashCommands, SlashCommandPalette } from '@/lib/slash-commands';
 import './PageEditor.css';
 
+function insertImageMarkdown(
+  textarea: HTMLTextAreaElement,
+  content: string,
+  setContent: (s: string) => void,
+  dataUrl: string,
+  fileName: string
+) {
+  const cursorPos = textarea.selectionStart;
+  const imageMarkdown = `![${fileName}](${dataUrl})\n`;
+  const newContent = content.slice(0, cursorPos) + imageMarkdown + content.slice(cursorPos);
+  setContent(newContent);
+  const newCursor = cursorPos + imageMarkdown.length;
+  requestAnimationFrame(() => {
+    textarea.setSelectionRange(newCursor, newCursor);
+    textarea.focus();
+  });
+}
+
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
+
 interface PageEditorProps {
   page: Page;
   onSave: (updatedPage: Page) => void;
@@ -16,6 +43,7 @@ export function PageEditor({ page, onSave, onCancel }: PageEditorProps) {
   const [title, setTitle] = useState(page.title);
   const [content, setContent] = useState(page.content);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const [tags, setTags] = useState(page.tags.join(', '));
   const [dueDate, setDueDate] = useState(page.dueDate ? page.dueDate.slice(0, 10) : '');
   const [selectedColumn, setSelectedColumn] = useState(page.kanbanColumn || '');
@@ -44,6 +72,47 @@ export function PageEditor({ page, onSave, onCancel }: PageEditorProps) {
   );
 
   const getColColor = (col: string) => columnColors[col.toLowerCase()];
+
+  const handlePaste = useCallback(async (e: React.ClipboardEvent) => {
+    const items = e.clipboardData?.items;
+    if (!items) return;
+    for (const item of Array.from(items)) {
+      if (item.type.startsWith('image/')) {
+        e.preventDefault();
+        const file = item.getAsFile();
+        if (!file || !textareaRef.current) return;
+        const dataUrl = await readFileAsDataUrl(file);
+        insertImageMarkdown(textareaRef.current, content, setContent, dataUrl, file.name || 'pasted-image');
+        return;
+      }
+    }
+  }, [content, setContent]);
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'copy';
+  }, []);
+
+  const handleDrop = useCallback(async (e: React.DragEvent) => {
+    const files = e.dataTransfer.files;
+    for (const file of Array.from(files)) {
+      if (file.type.startsWith('image/')) {
+        e.preventDefault();
+        if (!textareaRef.current) return;
+        const dataUrl = await readFileAsDataUrl(file);
+        insertImageMarkdown(textareaRef.current, content, setContent, dataUrl, file.name);
+        return;
+      }
+    }
+  }, [content, setContent]);
+
+  const handleImageFileSelect = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file || !textareaRef.current) return;
+    const dataUrl = await readFileAsDataUrl(file);
+    insertImageMarkdown(textareaRef.current, content, setContent, dataUrl, file.name);
+    e.target.value = '';
+  }, [content, setContent]);
 
   // Close dropdown on outside click
   useEffect(() => {
@@ -146,6 +215,16 @@ export function PageEditor({ page, onSave, onCancel }: PageEditorProps) {
           >
             Preview
           </button>
+          <button className="toolbar-btn" onClick={() => fileInputRef.current?.click()} title="Insert image">
+            <span className="material-symbols-outlined" style={{fontSize: '1.1rem'}}>image</span>
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            style={{ display: 'none' }}
+            onChange={handleImageFileSelect}
+          />
         </div>
         <div className="editor-toolbar-right">
           <button className="btn btn-secondary" onClick={onCancel}>
@@ -268,7 +347,11 @@ export function PageEditor({ page, onSave, onCancel }: PageEditorProps) {
           dangerouslySetInnerHTML={{ __html: previewHtml }}
         />
       ) : (
-        <div className="editor-textarea-wrapper">
+        <div
+          className="editor-textarea-wrapper"
+          onDragOver={handleDragOver}
+          onDrop={handleDrop}
+        >
           {slash.isOpen && slash.palettePosition && (
             <SlashCommandPalette
               commands={slash.filteredCommands}
@@ -287,6 +370,7 @@ export function PageEditor({ page, onSave, onCancel }: PageEditorProps) {
             onCompositionStart={slash.handleCompositionStart}
             onCompositionEnd={slash.handleCompositionEnd}
             onBlur={slash.handleBlur}
+            onPaste={handlePaste}
             placeholder="Type / for commands, or start writing..."
             spellCheck
           />


### PR DESCRIPTION
## Summary
- Clipboard paste detects images and inserts as data URL markdown
- Drag-and-drop images onto editor textarea
- Image button in toolbar opens native file picker
- Helper functions for cursor-aware markdown image insertion

## Issue
Addresses Issue #1 item: "사진 삽입 간편하게 할 수 있도록 지원 검토"

## Files Changed
- `src/components/PageEditor.tsx` — paste/drop/file handlers, image toolbar button
- `src/components/PageEditor.css` — image button styling

## Technical Notes
- Uses data URLs (base64) for simplicity and web/Tauri compatibility
- Future optimization: save to `workspace/assets/` folder with relative paths
- TypeScript clean (only pre-existing errors in fileSystem.ts)

## Test plan
- [ ] Copy an image, paste in editor — should insert `![filename](data:...)` 
- [ ] Drag an image file onto editor — should insert markdown
- [ ] Click image button in toolbar — should open file picker, insert on select
- [ ] Verify inserted images render correctly in preview mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)